### PR TITLE
Fix LookupGlobalManual hook

### DIFF
--- a/include/nn/ro.h
+++ b/include/nn/ro.h
@@ -104,6 +104,12 @@ namespace ro {
     Result RegisterModuleInfo(RegistrationInfo*, void const*);
     Result RegisterModuleInfo(RegistrationInfo*, void const*, uint);
     Result UnregisterModuleInfo(RegistrationInfo*);
+
+    namespace detail {
+        struct RoModule;
+        void* LookupGlobalManual(nn::ro::detail::RoModule const*, const char*);
+    };  // namespace detail
+    
 };  // namespace ro
 
 };  // namespace nn

--- a/include/nn/ro.h
+++ b/include/nn/ro.h
@@ -107,6 +107,7 @@ namespace ro {
 
     namespace detail {
         struct RoModule;
+        void* LookupGlobalManual(const char*);
         void* LookupGlobalManual(nn::ro::detail::RoModule const*, const char*);
     };  // namespace detail
     

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -29,8 +29,8 @@ void exception_handler(nn::os::UserExceptionInfo* info) {
 void* (*lookupGlobalManualImpl)();
 
 void* handleLookupGlobalManual(const char* symName) {
-    void* (*func)(const char*) = (void* (*)(const char*))(lookupGlobalManualImpl);
-    void* result = func(symName);
+    void* (*func_ptr)(const char*) = (void* (*)(const char*))(lookupGlobalManualImpl);
+    void* result = func_ptr(symName);
     if (result == nullptr) {
         uintptr_t mapValue = skyline::utils::SymbolMap::getSymbolAddress(std::string(symName));
         return reinterpret_cast<void*>(mapValue);
@@ -39,8 +39,8 @@ void* handleLookupGlobalManual(const char* symName) {
 }
 
 void* handleLookupGlobalManual(const void* module, const char* symName) {
-    void* (*func)(const void*, const char*) = (void* (*)(const void*, const char*))(lookupGlobalManualImpl);
-    void* result = func(module, symName);
+    void* (*func_ptr)(const void*, const char*) = (void* (*)(const void*, const char*))(lookupGlobalManualImpl);
+    void* result = func_ptr(module, symName);
     if (result == nullptr) {
         uintptr_t mapValue = skyline::utils::SymbolMap::getSymbolAddress(std::string(symName));
         return reinterpret_cast<void*>(mapValue);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -26,7 +26,7 @@ void exception_handler(nn::os::UserExceptionInfo* info) {
     skyline::logger::s_Instance->Flush();
 }
 
-void *(*lookupGlobalManualImpl)();
+void* (*lookupGlobalManualImpl)();
 
 void* handleLookupGlobalManual(const char* symName) {
     void* (*func)(const char*) = (void* (*)(const char*))(lookupGlobalManualImpl);


### PR DESCRIPTION
Hello. I saw your pr on the main repo and was unsure if you ever actually got the dynamic symbol linking part working. For at least the sdk of the game that I'm looking at, it uses a different function signature with two params for ``nn::ro::LookupGlobalManual``, so I resolved that. I also added the function prototype in the ``nn/ro`` header so it can be called without having to manually look up the offset of the function. Hopefully this agrees with your uses.